### PR TITLE
feat(application-assistant): multi-question input with improved AI answers

### DIFF
--- a/scripts/application-check.ts
+++ b/scripts/application-check.ts
@@ -11,7 +11,7 @@ import { prepareApplicationAnswers } from "../src/lib/applications/application-a
 const jobId = "northstar-principal-product-designer";
 const customQuestion = "Describe a product decision you influenced with research.";
 
-prepareApplicationAnswers(jobId, customQuestion);
+prepareApplicationAnswers(jobId, [customQuestion]);
 const drafts = getApplicationAnswerDrafts(jobId);
 
 assert.ok(drafts.length >= 6);

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -2,6 +2,8 @@ import { notFound, redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import Link from "next/link";
 import { ApplicationStatusSelect } from "@/components/application-status-select";
+import { ApplicationQuestionsForm } from "@/components/application-questions-form";
+import { CopyAnswerButton } from "@/components/copy-answer-button";
 import { GapAddressingPanel } from "@/components/gap-addressing-panel";
 import { ResumeGeneratorModal } from "@/components/resume-generator-modal";
 import { StreamingEvaluation } from "@/components/streaming-evaluation";
@@ -124,13 +126,13 @@ export default async function JobDetailPage({ params, searchParams }: Props) {
 
   async function prepareAnswersAction(formData: FormData) {
     "use server";
-    const customQuestion = String(formData.get("customQuestion") ?? "");
+    const customQuestions = formData.getAll("question").map(String).filter((q) => q.trim());
     const aiSettings = getAISettings();
     const hasAIKey = aiSettings.anthropicApiKey || aiSettings.geminiApiKey || aiSettings.openaiApiKey;
     if (hasAIKey) {
-      await prepareApplicationAnswersWithAI(id, customQuestion);
+      await prepareApplicationAnswersWithAI(id, customQuestions);
     } else {
-      prepareApplicationAnswers(id, customQuestion);
+      prepareApplicationAnswers(id, customQuestions);
     }
     revalidatePath(`/jobs/${id}`);
     revalidatePath("/applications");
@@ -608,30 +610,25 @@ export default async function JobDetailPage({ params, searchParams }: Props) {
             <Card>
               <CardHeader>
                 <CardTitle>Application assistant</CardTitle>
-                <CardDescription>Generate copy-paste answers for the application form using your evaluation and resume evidence.</CardDescription>
+                <CardDescription>Paste the questions from the application form and get AI-generated answers grounded in your resume and evaluation.</CardDescription>
               </CardHeader>
               <div className="grid gap-4">
-                <form action={prepareAnswersAction} className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
-                  <Textarea
-                    hint="Add a custom question from the application. Standard questions are generated automatically."
-                    label="Custom question (optional)"
-                    name="customQuestion"
-                    placeholder="Describe a product decision you influenced with research."
-                  />
-                  <SubmitButton label="Prepare answers" pendingLabel="Preparing…" savedLabel="Done ✓" variant="secondary" />
-                </form>
+                <ApplicationQuestionsForm action={prepareAnswersAction} />
                 {answerDrafts.length > 0 ? (
                   <ol className="grid gap-3">
                     {answerDrafts.map((draft) => (
                       <li className="rounded-control border border-border bg-surface px-3 py-3" key={draft.id}>
                         <p className="text-sm font-semibold text-ink">{draft.question}</p>
                         <p className="mt-2 text-sm leading-6 text-ink whitespace-pre-wrap">{draft.answer}</p>
-                        <p className="mt-2 text-xs text-muted">{draft.source}</p>
+                        <div className="mt-2 flex items-center justify-between gap-2">
+                          <p className="text-xs text-muted">{draft.source}</p>
+                          <CopyAnswerButton answer={draft.answer} />
+                        </div>
                       </li>
                     ))}
                   </ol>
                 ) : (
-                  <p className="text-sm text-muted">No drafts yet. Click Prepare drafts to generate answers.</p>
+                  <p className="text-sm text-muted">No drafts yet. Add your questions and click Prepare answers.</p>
                 )}
               </div>
             </Card>

--- a/src/components/application-questions-form.tsx
+++ b/src/components/application-questions-form.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { SubmitButton } from "@/components/ui";
+
+type Props = {
+  action: (formData: FormData) => void | Promise<void>;
+};
+
+export function ApplicationQuestionsForm({ action }: Props) {
+  const [questions, setQuestions] = useState<string[]>([""]);
+
+  function addQuestion() {
+    setQuestions((prev) => [...prev, ""]);
+  }
+
+  function removeQuestion(index: number) {
+    setQuestions((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function updateQuestion(index: number, value: string) {
+    setQuestions((prev) => prev.map((q, i) => (i === index ? value : q)));
+  }
+
+  return (
+    <form action={action} className="grid gap-3">
+      <div className="space-y-1.5">
+        <p className="text-sm font-medium text-ink">Application questions (optional)</p>
+        <p className="text-xs leading-5 text-muted">
+          Paste questions directly from the application form. Standard questions — why this role, fit, about you, compensation, work authorization — are always included.
+        </p>
+        <div className="grid gap-2 pt-1">
+          {questions.map((q, i) => (
+            <div className="flex gap-2 items-start" key={i}>
+              <textarea
+                className="min-h-[5rem] w-full rounded-control border border-border bg-panel px-3 py-2 text-sm leading-6 text-ink placeholder:text-muted"
+                name="question"
+                onChange={(e) => updateQuestion(i, e.target.value)}
+                placeholder="e.g. Describe a product decision you influenced with research."
+                rows={2}
+                value={q}
+              />
+              {questions.length > 1 && (
+                <button
+                  className="mt-2 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-control border border-border text-muted transition-colors hover:border-danger hover:text-danger"
+                  onClick={() => removeQuestion(i)}
+                  type="button"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          className="text-sm text-accent hover:underline"
+          onClick={addQuestion}
+          type="button"
+        >
+          + Add another question
+        </button>
+        <div className="flex-1" />
+        <SubmitButton
+          label="Prepare answers"
+          pendingLabel="Preparing…"
+          savedLabel="Done ✓"
+          variant="secondary"
+        />
+      </div>
+    </form>
+  );
+}

--- a/src/components/copy-answer-button.tsx
+++ b/src/components/copy-answer-button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+
+export function CopyAnswerButton({ answer }: { answer: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(answer);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      className="text-xs text-muted transition-colors hover:text-ink"
+      onClick={handleCopy}
+      type="button"
+    >
+      {copied ? "Copied ✓" : "Copy"}
+    </button>
+  );
+}

--- a/src/lib/applications/application-assistant.ts
+++ b/src/lib/applications/application-assistant.ts
@@ -25,7 +25,7 @@ const commonQuestions = [
   "Do you have any location or work authorization constraints?"
 ];
 
-export function prepareApplicationAnswers(jobId: string, customQuestion?: string) {
+export function prepareApplicationAnswers(jobId: string, customQuestions: string[] = []) {
   const job = getJobById(jobId);
   if (!job) {
     throw new Error(`Job not found: ${jobId}`);
@@ -49,7 +49,10 @@ export function prepareApplicationAnswers(jobId: string, customQuestion?: string
     profile,
     generatedResumeTitle: generatedDocument?.title ?? "No generated resume is attached yet"
   };
-  const questions = [...commonQuestions, cleanQuestion(customQuestion)].filter(Boolean) as string[];
+  const questions = [
+    ...commonQuestions,
+    ...customQuestions.map(cleanQuestion).filter(Boolean) as string[]
+  ];
   const drafts = questions.map((question, index) => buildDraft(context, question, index));
 
   saveApplicationAnswerDrafts(drafts);

--- a/src/lib/applications/llm-answer-generator.ts
+++ b/src/lib/applications/llm-answer-generator.ts
@@ -15,7 +15,7 @@ import type { ApplicationAnswerDraftInput } from "../db/types";
 import { evaluateJob } from "../evaluation/job-evaluator";
 import { formatStyleForPrompt } from "../profile/writing-style-extractor";
 
-export async function prepareApplicationAnswersWithAI(jobId: string, customQuestion?: string) {
+export async function prepareApplicationAnswersWithAI(jobId: string, customQuestions: string[] = []) {
   const job = getJobById(jobId);
   if (!job) throw new Error(`Job not found: ${jobId}`);
 
@@ -40,7 +40,17 @@ export async function prepareApplicationAnswersWithAI(jobId: string, customQuest
     ? `\n\n${formatStyleForPrompt(writingStyle.toneProfile)}`
     : "";
 
-  const systemPrompt = `You are a job application coach writing copy-paste ready answers for a job seeker. Write in first person, professional but natural tone. Be specific — reference the actual company name and role. Draw only from the candidate context provided. Never start answers with "I am" or "I'm". Keep answers under 150 words each.
+  const systemPrompt = `You are an experienced career coach helping a candidate write authentic, compelling job application answers. Your goal is to craft responses that sound genuinely human — not AI-generated — and are specific enough to earn an interview callback.
+
+Rules:
+- Write in first person with a natural, conversational-yet-professional voice
+- Never open with "I am", "I'm", "As a", or "With X years of experience"
+- Vary sentence length; mix short punchy statements with longer elaborations
+- Be concrete: name the company and role, cite real evidence from the candidate's background
+- Avoid corporate buzzwords (leverage, synergize, passionate about, etc.)
+- Each answer should feel like it came from a thoughtful human who has done their research
+- Keep answers 2–5 sentences; under 150 words
+- Draw only from the candidate context provided — never fabricate credentials
 
 Candidate: ${profile.name}
 Goal: ${profile.currentSearchGoal}
@@ -59,25 +69,25 @@ Resume evidence: ${evaluation.resumeEvidence.slice(0, 3).join("; ")}${storyConte
     "Do you have any location or work authorization constraints?"
   ];
 
-  if (customQuestion?.trim()) {
-    commonQuestions.push(customQuestion.trim());
+  for (const q of customQuestions) {
+    if (q.trim()) commonQuestions.push(q.trim());
   }
 
   const messages: AIMessage[] = [
     { role: "system", content: systemPrompt },
     {
       role: "user",
-      content: `Write copy-paste ready answers for these job application questions.
+      content: `Write copy-paste ready answers for these job application questions. Each answer must sound like a real human wrote it — natural, specific, and interview-worthy.
 
-Job: ${job.title} at ${job.company}
+Role: ${job.title} at ${job.company}
 Location: ${job.location} / ${job.remoteType}
-Salary: ${job.salaryNotes}
+Salary context: ${job.salaryNotes}
 
-Questions:
+Questions to answer:
 ${commonQuestions.map((q, i) => `${i + 1}. ${q}`).join("\n")}
 
 Return a JSON object: { "answers": ["answer 1", "answer 2", ...] }
-One answer per question in the same order. Each answer should be 2-4 sentences, specific to ${job.company} and ${job.title}.`
+Exactly one answer per question, in the same order. Vary the opening words across answers. Make each one feel distinct and authentic to this specific role at ${job.company}.`
     }
   ];
 


### PR DESCRIPTION
## Summary

- Replace the single optional custom-question textarea with a dynamic form where users can add/remove as many application questions as they need
- Overhaul the AI system prompt to generate natural, human-sounding answers — explicit rules against AI tells (clichéd openers like "I am", buzzwords, uniform sentence length)
- Add a **Copy** button to each generated answer draft for quick paste into forms

## Changes

**New components**
- `src/components/application-questions-form.tsx` — client component with dynamic add/remove question inputs and the Prepare answers submit button
- `src/components/copy-answer-button.tsx` — lightweight clipboard copy button rendered per answer draft

**Updated**
- `src/lib/applications/llm-answer-generator.ts` — signature changed from `customQuestion?: string` → `customQuestions: string[]`; system prompt rewritten with explicit humanization rules
- `src/lib/applications/application-assistant.ts` — same signature change for the rule-based fallback path
- `src/app/jobs/[id]/page.tsx` — server action reads all `question` fields via `formData.getAll()`; UI swapped to `ApplicationQuestionsForm`; answer list renders `CopyAnswerButton`
- `scripts/application-check.ts` — updated test call to pass an array

## Test plan

- [ ] Open any job's Apply tab — Application assistant section shows one empty question textarea with add/remove controls
- [ ] Add 2–3 custom questions, click Prepare answers — all questions appear in the generated drafts alongside the 5 standard questions
- [ ] Leaving all question fields empty still generates the 5 standard answers
- [ ] Copy button on each draft copies the answer text to clipboard
- [ ] TypeScript: `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)