### PR TITLE
Add Import All Valid, source validation, search discovery, and Adzuna…

### DIFF
--- a/docs/browser-board-scanner-technical.md
+++ b/docs/browser-board-scanner-technical.md
@@ -40,6 +40,12 @@ importBrowserBoardJobs()
 | Glassdoor | `glassdoor` | `glassdoor-browser-scan` |
 | Indeed | `indeed` | `indeed-browser-scan` |
 | Monster | `monster` | `monster-browser-scan` |
+| Adzuna | `adzuna` | `adzuna-api-scan` |
+
+Adzuna uses a direct API scan (`src/lib/scanner/aggregator-scanner.ts`) rather
+than browser automation. The `metadata.source` value `"adzuna"` is recognised
+by the same importer pipeline, and the scan type `"adzuna-api-scan"` is stored
+in `scan_runs.scan_type`.
 
 Legacy LinkedIn files without `metadata.source` remain supported when imported
 through the legacy LinkedIn directory or route.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -50,6 +50,7 @@ and initializes an empty local profile if the database is empty.
 | `0034_remove_legacy_demo_resumes` | Removes five hard-coded demo resume lane records left behind by `0030` (IDs: `accessibility-design-systems`, `ux-design`, `design-operations`, `principal-product-design`, `teaching-ux-education`); cascades to `resume_builder_versions` |
 | `0035_browser_board_job_provenance` | Adds `source_url`, `original_posting_url`, and `original_posting_key` to support browser-assisted LinkedIn, Wellfound, Work at a Startup, Glassdoor, Indeed, and Monster imports |
 | `0036_gap_answer_quality` | Adds quality-status, follow-up question, and assessment metadata to gap responses and profile supplements |
+| `0037_discovery_and_aggregator_keys` | Adds `brave_search_api_key`, `adzuna_app_id`, and `adzuna_api_key` to `ai_settings` to support search-based source discovery (Brave) and the Adzuna job aggregator scanner |
 
 ---
 
@@ -351,6 +352,9 @@ Singleton row holding AI provider configuration.
 | `fallback_provider` | Optional fallback provider |
 | `onboarding_dismissed` | 0 = show onboarding, 1 = dismissed |
 | `onboarding_preferences_confirmed` | 0 = first-run job preferences still need user confirmation, 1 = confirmed |
+| `brave_search_api_key` | Optional Brave Search API key for search-based ATS source discovery |
+| `adzuna_app_id` | Optional Adzuna App ID for the job aggregator scanner |
+| `adzuna_api_key` | Optional Adzuna API key for the job aggregator scanner |
 | `updated_at` | ISO timestamp |
 
 ### ai_prompt_overrides

--- a/docs/features.md
+++ b/docs/features.md
@@ -545,7 +545,18 @@ Three configuration tabs:
   config file); manually added sources have a Remove button.
 - Add any company by pasting its careers page URL — Greenhouse, Ashby, and
   Lever are auto-detected.
-- "Scan for new sources" discovers additional Greenhouse boards automatically.
+- "Scan for new sources" queries the Common Crawl index to discover additional
+  ATS boards automatically.
+- "Import all valid (N)" bulk-imports all currently valid discovered sources
+  into the tracked list in one click (only shown when there are valid
+  unimported entries).
+- "Search discover" queries Brave Search API for ATS job boards not in Common
+  Crawl (requires Brave Search API key in AI Provider settings). Merges new
+  findings into `data/discovered-sources.json` without overwriting existing
+  entries.
+- "Validate sources" checks live job counts for all tracked sources; shows a
+  "Live / N jobs", "Dead", or "Unknown" badge in a per-row column. A
+  "Re-validate sources" button re-runs the check after the first run.
 
 ### Preferences
 - Edit title include / exclude filters.
@@ -629,6 +640,8 @@ Location matching uses the selected Location mode checkboxes:
 
 An optional feature for users with Claude Desktop or Codex Chrome. An agent browses visible job-board results on your behalf and writes discovered jobs directly into Job Search Terminal — no copy-paste required. Supported browser-board sources are LinkedIn, Wellfound, Work at a Startup, Glassdoor, Indeed, and Monster.
 
+A separate **Adzuna API scanner** (Settings → Sources → Job aggregators card) pulls matching jobs directly from the Adzuna aggregator API without requiring a browser. It uses the same import pipeline as browser-board scans. Requires an Adzuna App ID and API Key configured in Settings → AI Provider → Discovery &amp; Aggregators.
+
 **How it works:**
 1. Ask Claude or Codex to scan LinkedIn, Wellfound, Work at a Startup, Glassdoor, Indeed, or Monster
 2. The agent reads your target roles and location preferences from the JST database
@@ -637,10 +650,10 @@ An optional feature for users with Claude Desktop or Codex Chrome. An agent brow
 5. Job Search Terminal detects the file, imports jobs with duplicate detection, and shows a notification
 
 **UI indicators on the Jobs table:**
-- **LinkedIn**, **Wellfound**, **Work at a Startup**, **Glassdoor**, **Indeed**, or **Monster** badge (neutral gray) — source column — identifies jobs discovered via browser-board scans
+- **LinkedIn**, **Wellfound**, **Work at a Startup**, **Glassdoor**, **Indeed**, **Monster**, or **Adzuna** badge (neutral gray) — source column — identifies jobs discovered via browser-board scans or aggregator API scans
 - **Manual** badge (neutral gray) — source column — identifies jobs added manually via the Add Job modal
 - **Duplicate** badge (amber, clickable) — flagged jobs whose URL or company+title already existed in the database. Clicking the badge instantly filters the table to show only duplicate-flagged jobs. Clicking again clears the filter.
-- **Source** column — filterable and sortable; options are "LinkedIn", "Wellfound", "Work at a Startup", "Glassdoor", "Indeed", "Monster", "Manual", and "Scanner"
+- **Source** column — filterable and sortable; options are "LinkedIn", "Wellfound", "Work at a Startup", "Glassdoor", "Indeed", "Monster", "Adzuna", "Manual", and "Scanner"
 
 **URL behavior:** Browser-board imports prefer a visible job-specific employer/ATS apply URL. If one is not available, the platform job URL is used and preserved as provenance.
 

--- a/src/app/api/aggregator/scan/route.ts
+++ b/src/app/api/aggregator/scan/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { getAISettings, getUserProfile } from "@/lib/db/queries";
+import { runAggregatorScan } from "@/lib/scanner/aggregator-scanner";
+
+export async function POST() {
+  try {
+    const settings = getAISettings();
+    const profile = getUserProfile();
+    const result = await runAggregatorScan({
+      adzunaAppId: settings.adzunaAppId,
+      adzunaApiKey: settings.adzunaApiKey,
+      titles: profile.targetRoles,
+      locations: profile.preferredLocations,
+      remotePreference: profile.remotePreference,
+    });
+    return NextResponse.json(result);
+  } catch (e) {
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -20,6 +20,9 @@ export async function saveAISettingsAction(formData: FormData) {
   const geminiModel = (formData.get("geminiModel") as string) || "gemini-2.0-flash";
   const openaiModel = (formData.get("openaiModel") as string) || "gpt-4o";
   const fallbackProvider = (formData.get("fallbackProvider") as string) ?? "";
+  const submittedBraveKey = (formData.get("braveSearchApiKey") as string) ?? "";
+  const adzunaAppId = (formData.get("adzunaAppId") as string) ?? "";
+  const submittedAdzunaKey = (formData.get("adzunaApiKey") as string) ?? "";
 
   const validProviders: AIProviderName[] = ["anthropic", "gemini", "openai"];
   if (!validProviders.includes(activeProvider)) {
@@ -30,6 +33,8 @@ export async function saveAISettingsAction(formData: FormData) {
   const anthropicApiKey = resolveKey(submittedAnthropicKey, stored.anthropicApiKey);
   const geminiApiKey = resolveKey(submittedGeminiKey, stored.geminiApiKey);
   const openaiApiKey = resolveKey(submittedOpenaiKey, stored.openaiApiKey);
+  const braveSearchApiKey = resolveKey(submittedBraveKey, stored.braveSearchApiKey);
+  const adzunaApiKey = resolveKey(submittedAdzunaKey, stored.adzunaApiKey);
 
   saveAISettings({
     activeProvider,
@@ -42,6 +47,9 @@ export async function saveAISettingsAction(formData: FormData) {
     fallbackProvider,
     onboardingDismissed: stored.onboardingDismissed,
     onboardingPreferencesConfirmed: stored.onboardingPreferencesConfirmed,
+    braveSearchApiKey,
+    adzunaAppId,
+    adzunaApiKey,
   });
 
   revalidatePath("/settings");

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,6 +11,7 @@ import {
   getProfileSupplements,
   getScanSourceOverrides,
   getTitleFilters,
+  getUserProfile,
   saveTitleFilters,
   setScanSourceEnabled,
   syncCompanyProfilesFromYaml,
@@ -24,9 +25,11 @@ import { ProfileSupplementsEditor } from "@/components/profile-supplements-edito
 import { DiscoveredSourcesButton } from "@/components/discovered-sources-button";
 import { ScanJobsForm } from "@/components/scan-jobs-form";
 import { ScanSourcesTable, type CompanyScanResultSummary } from "@/components/scan-sources-table";
+import { AggregatorScanButton } from "@/components/aggregator-scan-button";
 import { SCAN_RESULT_JOBS_PREVIEW_MAX } from "@/lib/scan-result-constants";
 import { detectApi, loadScanConfig, runCareerOpsScanner } from "@/lib/scanner/careerops-scanner";
-import { runSourceDiscovery } from "@/lib/scanner/source-discovery";
+import { runSourceDiscovery, runSearchDiscovery } from "@/lib/scanner/source-discovery";
+import type { SourceValidationResult } from "@/lib/scanner/source-validator";
 import { cn } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
@@ -142,6 +145,7 @@ export default async function SettingsPage({
   const importableDiscovered = allDiscovered.filter(
     (e) => e.validationStatus === "valid" && !existingNames.has(e.slug.toLowerCase())
   );
+  const validDiscoveredCount = importableDiscovered.length;
 
   // ── Server actions ──────────────────────────────────────────────────────────
 
@@ -151,6 +155,56 @@ export default async function SettingsPage({
       console.info(`[discover-sources] ${msg}`);
     });
     revalidatePath("/settings");
+  }
+
+  async function importAllValidAction() {
+    "use server";
+    const discovered = loadDiscoveredSources();
+    const cfg = loadScanConfig();
+    const cfgNames = new Set((cfg.tracked_companies ?? []).map((c) => c.name.toLowerCase()));
+    const custom = getCustomScanSources();
+    const customNames = new Set(custom.map((c) => c.name.toLowerCase()));
+    const existing = new Set([...cfgNames, ...customNames]);
+    const toImport = discovered.filter(
+      (e) => e.validationStatus === "valid" && !existing.has(e.slug.toLowerCase())
+    );
+    for (const entry of toImport) {
+      addCustomScanSource(entry.slug, entry.careersUrl, entry.apiUrl ?? "");
+      if (entry.industry) upsertCompanyProfile(entry.slug, entry.industry);
+    }
+    revalidatePath("/settings");
+  }
+
+  async function validateAllSourcesAction(): Promise<SourceValidationResult[]> {
+    "use server";
+    const { validateAllSources } = await import("@/lib/scanner/source-validator");
+    return validateAllSources(
+      allCompanies.map((c) => ({ name: c.name, careersUrl: c.careersUrl, apiType: c.apiType }))
+    );
+  }
+
+  async function searchDiscoverSourcesAction() {
+    "use server";
+    const currentSettings = getAISettings();
+    if (!currentSettings.braveSearchApiKey) throw new Error("Brave Search API key not configured");
+    await runSearchDiscovery(currentSettings.braveSearchApiKey, (msg) => {
+      console.info(`[search-discover] ${msg}`);
+    });
+    revalidatePath("/settings");
+  }
+
+  async function runAggregatorScanAction() {
+    "use server";
+    const currentSettings = getAISettings();
+    const profile = getUserProfile();
+    const { runAggregatorScan } = await import("@/lib/scanner/aggregator-scanner");
+    return runAggregatorScan({
+      adzunaAppId: currentSettings.adzunaAppId,
+      adzunaApiKey: currentSettings.adzunaApiKey,
+      titles: profile.targetRoles,
+      locations: profile.preferredLocations,
+      remotePreference: profile.remotePreference,
+    });
   }
 
   async function toggleSourceEnabledAction(name: string, enabled: boolean) {
@@ -293,12 +347,28 @@ export default async function SettingsPage({
                   </CardDescription>
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
+                  {validDiscoveredCount > 0 && (
+                    <form action={importAllValidAction}>
+                      <SubmitButton
+                        label={`Import all valid (${validDiscoveredCount})`}
+                        pendingLabel="Importing…"
+                        variant="primary"
+                      />
+                    </form>
+                  )}
                   <DiscoveredSourcesButton entries={importableDiscovered} onImport={importDiscoveredAction} />
                   <ScanJobsForm
                     action={discoverSourcesAction}
                     label="Scan for new sources"
                     pendingLabel="Discovering…"
                   />
+                  {settings.braveSearchApiKey && (
+                    <ScanJobsForm
+                      action={searchDiscoverSourcesAction}
+                      label="Search discover"
+                      pendingLabel="Searching…"
+                    />
+                  )}
                 </div>
               </div>
               <ScanSourcesTable
@@ -308,6 +378,7 @@ export default async function SettingsPage({
                 onRemove={removeSourceAction}
                 onSaveIndustry={saveIndustryAction}
                 onScanCompany={scanCompanyJobsAction}
+                onValidateAll={validateAllSourcesAction}
               />
             </Card>
 
@@ -341,6 +412,23 @@ export default async function SettingsPage({
                   <SubmitButton label="Add company" savedLabel="Added" variant="primary" />
                 </div>
               </form>
+            </Card>
+
+            {/* Job aggregators */}
+            <Card>
+              <div className="mb-4 flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <CardTitle>Job aggregators</CardTitle>
+                  <CardDescription>
+                    Scan Adzuna to pull matching jobs directly from aggregator APIs into your pipeline.
+                    Configure your Adzuna App ID and API Key in the AI Provider tab.
+                  </CardDescription>
+                </div>
+                <AggregatorScanButton
+                  onScan={runAggregatorScanAction}
+                  hasCredentials={Boolean(settings.adzunaAppId && settings.adzunaApiKey)}
+                />
+              </div>
             </Card>
           </>
         )}

--- a/src/components/aggregator-scan-button.tsx
+++ b/src/components/aggregator-scan-button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { AggregatorScanResult } from "@/lib/scanner/aggregator-scanner";
+
+type Props = {
+  onScan: () => Promise<AggregatorScanResult>;
+  hasCredentials: boolean;
+};
+
+export function AggregatorScanButton({ onScan, hasCredentials }: Props) {
+  const [result, setResult] = useState<AggregatorScanResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleScan() {
+    setResult(null);
+    setError(null);
+    startTransition(async () => {
+      try {
+        const r = await onScan();
+        setResult(r);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+  }
+
+  if (!hasCredentials) {
+    return (
+      <p className="text-xs text-muted">
+        Add Adzuna credentials in the AI Provider tab to enable.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <button
+        type="button"
+        onClick={handleScan}
+        disabled={isPending}
+        className="inline-flex items-center gap-2 rounded-control border border-accent bg-accent px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-[rgb(var(--color-accent-strong))] disabled:cursor-not-allowed disabled:opacity-55"
+      >
+        {isPending ? "Scanning…" : "Scan with Adzuna"}
+      </button>
+      {result && result.status !== "no-credentials" && (
+        <p className="text-xs text-muted">
+          {result.status === "ok"
+            ? `Done — ${result.imported} new, ${result.duplicates} duplicates (${result.totalFound} found)`
+            : `Error: ${result.errors[0] ?? "Unknown error"}`}
+        </p>
+      )}
+      {result?.status === "no-credentials" && (
+        <p className="text-xs text-danger">Adzuna credentials not configured.</p>
+      )}
+      {error && <p className="text-xs text-danger">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/ai-settings-form.tsx
+++ b/src/components/ai-settings-form.tsx
@@ -29,6 +29,9 @@ export function AISettingsForm({ onSaved, settings, submitLabel = "Save settings
   const [geminiModel, setGeminiModel] = useState(settings.geminiModel || "gemini-2.5-flash");
   const [openaiModel, setOpenaiModel] = useState(settings.openaiModel || "gpt-5.4-mini");
   const [fallbackProvider, setFallbackProvider] = useState(settings.fallbackProvider);
+  const [braveSearchApiKey, setBraveSearchApiKey] = useState(settings.braveSearchApiKey ?? "");
+  const [adzunaAppId, setAdzunaAppId] = useState(settings.adzunaAppId ?? "");
+  const [adzunaApiKey, setAdzunaApiKey] = useState(settings.adzunaApiKey ?? "");
   const [showKeys, setShowKeys] = useState<Record<AIProviderName, boolean>>({ anthropic: false, gemini: false, openai: false });
   const [testStates, setTestStates] = useState<Record<AIProviderName, ProviderTestState>>({
     anthropic: { status: "idle" },
@@ -77,6 +80,9 @@ export function AISettingsForm({ onSaved, settings, submitLabel = "Save settings
     fd.set("geminiModel", geminiModel);
     fd.set("openaiModel", openaiModel);
     fd.set("fallbackProvider", fallbackProvider);
+    fd.set("braveSearchApiKey", braveSearchApiKey);
+    fd.set("adzunaAppId", adzunaAppId);
+    fd.set("adzunaApiKey", adzunaApiKey);
     startTransition(async () => {
       await saveAISettingsAction(fd);
       setSaved(true);
@@ -233,6 +239,47 @@ export function AISettingsForm({ onSaved, settings, submitLabel = "Save settings
           ))}
         </select>
         <p className="text-xs text-muted">Used automatically if the active provider fails.</p>
+      </div>
+
+      {/* Discovery & Aggregators */}
+      <div className="grid gap-3 border border-border rounded-md p-4">
+        <span className="text-sm font-medium text-ink">Discovery &amp; Aggregators</span>
+        <p className="text-xs text-muted">Optional keys for search-based source discovery (Brave) and job aggregator scanning (Adzuna).</p>
+
+        <div className="grid gap-2">
+          <label className="text-xs text-muted">Brave Search API Key <span className="text-muted/60">(for Sources &rarr; Search discover)</span></label>
+          <input
+            className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-ink font-mono placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+            onChange={(e) => setBraveSearchApiKey(e.target.value)}
+            placeholder="BSA…"
+            type="password"
+            value={braveSearchApiKey}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="grid gap-2">
+            <label className="text-xs text-muted">Adzuna App ID</label>
+            <input
+              className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-ink font-mono placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+              onChange={(e) => setAdzunaAppId(e.target.value)}
+              placeholder="xxxxxxxx"
+              type="text"
+              value={adzunaAppId}
+            />
+          </div>
+          <div className="grid gap-2">
+            <label className="text-xs text-muted">Adzuna API Key</label>
+            <input
+              className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-ink font-mono placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+              onChange={(e) => setAdzunaApiKey(e.target.value)}
+              placeholder="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+              type="password"
+              value={adzunaApiKey}
+            />
+          </div>
+        </div>
+        <p className="text-xs text-muted/70">Free Adzuna keys: <span className="font-mono">developer.adzuna.com</span>. Free Brave Search keys: <span className="font-mono">brave.com/search/api</span>.</p>
       </div>
 
       <div className="flex items-center gap-3">

--- a/src/components/scan-sources-table.tsx
+++ b/src/components/scan-sources-table.tsx
@@ -42,6 +42,7 @@ type Props = {
   onRemove: (name: string) => Promise<void>;
   onSaveIndustry: (name: string, industry: string) => Promise<void>;
   onScanCompany: (companyName: string) => Promise<CompanyScanResultSummary>;
+  onValidateAll?: () => Promise<Array<{ name: string; status: string; jobCount: number | null }>>;
 };
 
 type SortCol = "company" | "industry" | "ats" | "status";
@@ -83,6 +84,7 @@ export function ScanSourcesTable({
   onRemove,
   onSaveIndustry,
   onScanCompany,
+  onValidateAll,
 }: Props) {
   const router = useRouter();
   const {
@@ -116,6 +118,8 @@ export function ScanSourcesTable({
   const [scanResult, setScanResult] = useState<ScanJobResultSummary | null>(null);
   const [scanningName, setScanningName] = useState<string | null>(null);
   const [scanError, setScanError] = useState<string | null>(null);
+  const [validationMap, setValidationMap] = useState<Map<string, { status: string; jobCount: number | null }>>(new Map());
+  const [validating, setValidating] = useState(false);
 
   function handleToggle(name: string) {
     const currentEnabled = enabledOverrides.has(name)
@@ -207,6 +211,17 @@ export function ScanSourcesTable({
     });
   }
 
+  async function handleValidateAll() {
+    if (!onValidateAll) return;
+    setValidating(true);
+    try {
+      const results = await onValidateAll();
+      setValidationMap(new Map(results.map((r) => [r.name, { status: r.status, jobCount: r.jobCount }])));
+    } finally {
+      setValidating(false);
+    }
+  }
+
   return (
     <div className="relative">
       {(activeFilterCount > 0 ||
@@ -232,6 +247,19 @@ export function ScanSourcesTable({
             />
           }
         />
+      )}
+
+      {onValidateAll && (
+        <div className="mb-2 flex justify-end">
+          <button
+            type="button"
+            onClick={() => void handleValidateAll()}
+            disabled={validating}
+            className="text-xs text-muted hover:text-ink disabled:opacity-50"
+          >
+            {validating ? "Validating…" : validationMap.size > 0 ? "Re-validate sources" : "Validate sources"}
+          </button>
+        </div>
       )}
 
       <div className="w-full max-w-full" role="region" aria-label="Scan sources table">
@@ -260,6 +288,9 @@ export function ScanSourcesTable({
                   onOpen={openFilter}
                 />
               ))}
+              {validationMap.size > 0 && (
+                <th className="pb-3 pr-4 text-left text-xs font-semibold uppercase tracking-wider text-muted w-24">Live</th>
+              )}
               <th className="pb-3 text-left text-xs font-semibold uppercase tracking-wider text-muted w-28">
                 Scan
               </th>
@@ -310,6 +341,17 @@ export function ScanSourcesTable({
                       {isEnabled ? "Enabled" : "Disabled"}
                     </Badge>
                   </td>
+                  {validationMap.size > 0 && (
+                    <td className="py-3 pr-4">
+                      {(() => {
+                        const v = validationMap.get(source.name);
+                        if (!v) return <span className="text-xs text-muted">—</span>;
+                        if (v.status === "valid") return <Badge tone="success">{v.jobCount !== null ? `${v.jobCount} jobs` : "Live"}</Badge>;
+                        if (v.status === "dead") return <Badge tone="danger">Dead</Badge>;
+                        return <Badge tone="neutral">Unknown</Badge>;
+                      })()}
+                    </td>
+                  )}
                   <td className="py-3 pr-4">
                     <Button
                       aria-label={`Scan for new jobs at ${source.name}`}

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -1366,7 +1366,8 @@ export type BrowserBoardJobInput = {
     | "workatastartup-browser-scan"
     | "glassdoor-browser-scan"
     | "indeed-browser-scan"
-    | "monster-browser-scan";
+    | "monster-browser-scan"
+    | "adzuna-api-scan";
   location: string;
   rawDescription: string;
   datePosted: string | null;
@@ -1833,6 +1834,9 @@ type AISettingsRow = {
   fallback_provider: string;
   onboarding_dismissed: number;
   onboarding_preferences_confirmed: number;
+  brave_search_api_key: string;
+  adzuna_app_id: string;
+  adzuna_api_key: string;
   updated_at: string;
 };
 
@@ -1851,6 +1855,9 @@ export function getAISettings(): AISettingsRecord {
       fallbackProvider: "",
       onboardingDismissed: false,
       onboardingPreferencesConfirmed: false,
+      braveSearchApiKey: "",
+      adzunaAppId: "",
+      adzunaApiKey: "",
       updatedAt: new Date().toISOString()
     };
   }
@@ -1866,11 +1873,15 @@ export function getAISettings(): AISettingsRecord {
     fallbackProvider: row.fallback_provider,
     onboardingDismissed: Boolean(row.onboarding_dismissed),
     onboardingPreferencesConfirmed: Boolean(row.onboarding_preferences_confirmed),
+    braveSearchApiKey: row.brave_search_api_key ?? "",
+    adzunaAppId: row.adzuna_app_id ?? "",
+    adzunaApiKey: row.adzuna_api_key ?? "",
     updatedAt: row.updated_at
   };
 }
 
 export function saveAISettings(input: AISettingsUpdateInput) {
+  const existing = getAISettings();
   getDatabase()
     .prepare(
       `update ai_settings set
@@ -1884,13 +1895,19 @@ export function saveAISettings(input: AISettingsUpdateInput) {
         fallback_provider = @fallbackProvider,
         onboarding_dismissed = @onboardingDismissed,
         onboarding_preferences_confirmed = @onboardingPreferencesConfirmed,
+        brave_search_api_key = @braveSearchApiKey,
+        adzuna_app_id = @adzunaAppId,
+        adzuna_api_key = @adzunaApiKey,
         updated_at = current_timestamp
       where id = 'singleton'`
     )
     .run({
       ...input,
       onboardingDismissed: input.onboardingDismissed ? 1 : 0,
-      onboardingPreferencesConfirmed: input.onboardingPreferencesConfirmed ? 1 : 0
+      onboardingPreferencesConfirmed: input.onboardingPreferencesConfirmed ? 1 : 0,
+      braveSearchApiKey: input.braveSearchApiKey ?? existing.braveSearchApiKey,
+      adzunaAppId: input.adzunaAppId ?? existing.adzunaAppId,
+      adzunaApiKey: input.adzunaApiKey ?? existing.adzunaApiKey,
     });
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -660,5 +660,13 @@ export const migrations = [
       alter table profile_gap_supplements add column assessment_json text not null default '{}';
       alter table profile_gap_supplements add column assessed_at text;
     `
+  },
+  {
+    id: "0037_discovery_and_aggregator_keys",
+    sql: `
+      alter table ai_settings add column brave_search_api_key text not null default '';
+      alter table ai_settings add column adzuna_app_id text not null default '';
+      alter table ai_settings add column adzuna_api_key text not null default '';
+    `
   }
 ];

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -180,7 +180,8 @@ export type ScanRunRecord = {
     | "workatastartup-browser-scan"
     | "glassdoor-browser-scan"
     | "indeed-browser-scan"
-    | "monster-browser-scan";
+    | "monster-browser-scan"
+    | "adzuna-api-scan";
 };
 
 export type ImportResult = {
@@ -216,7 +217,7 @@ export type LinkedInScanFile = {
 
 export type BrowserBoardScanFile = {
   metadata: {
-    source: "linkedin" | "wellfound" | "workatastartup" | "glassdoor" | "indeed" | "monster";
+    source: "linkedin" | "wellfound" | "workatastartup" | "glassdoor" | "indeed" | "monster" | "adzuna";
     scanTimestamp: string;
     scanDurationSeconds: number;
     totalJobsDiscovered: number;
@@ -475,6 +476,9 @@ export type AISettingsRecord = {
   fallbackProvider: string;
   onboardingDismissed: boolean;
   onboardingPreferencesConfirmed: boolean;
+  braveSearchApiKey: string;
+  adzunaAppId: string;
+  adzunaApiKey: string;
   updatedAt: string;
 };
 
@@ -489,6 +493,9 @@ export type AISettingsUpdateInput = {
   fallbackProvider: string;
   onboardingDismissed?: boolean;
   onboardingPreferencesConfirmed?: boolean;
+  braveSearchApiKey?: string;
+  adzunaAppId?: string;
+  adzunaApiKey?: string;
 };
 
 export type AIPromptId =

--- a/src/lib/scanner/aggregator-scanner.ts
+++ b/src/lib/scanner/aggregator-scanner.ts
@@ -1,0 +1,203 @@
+import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { safeFetch } from "@/lib/safe-fetch";
+import { getBrowserBoardImportDirectory, importBrowserBoardJobs } from "./browser-board-importer";
+
+export type AggregatorScanOptions = {
+  adzunaAppId: string;
+  adzunaApiKey: string;
+  titles: string[];
+  locations: string[];
+  remotePreference: string;
+  country?: string;
+};
+
+export type AggregatorScanResult = {
+  status: "ok" | "error" | "no-credentials";
+  imported: number;
+  duplicates: number;
+  totalFound: number;
+  errors: string[];
+};
+
+type AdzunaJob = {
+  id: string;
+  title: string;
+  company: { display_name: string };
+  description: string;
+  redirect_url: string;
+  location: { display_name: string };
+  salary_min?: number;
+  salary_max?: number;
+  created: string;
+};
+
+type AdzunaResponse = {
+  count: number;
+  results: AdzunaJob[];
+};
+
+async function searchAdzuna(
+  appId: string,
+  apiKey: string,
+  what: string,
+  where: string,
+  country: string,
+): Promise<AdzunaJob[]> {
+  const params = new URLSearchParams({
+    app_id: appId,
+    app_key: apiKey,
+    what,
+    results_per_page: "50",
+    sort_by: "date",
+    max_days_old: "14",
+  });
+  if (where) params.set("where", where);
+  const url = `https://api.adzuna.com/v1/api/jobs/${country}/search/1?${params}`;
+  const res = await safeFetch(url);
+  if (!res.ok) {
+    if (res.status === 401 || res.status === 403) throw new Error("Invalid Adzuna credentials — check your App ID and API Key");
+    if (res.status === 404) return [];
+    throw new Error(`Adzuna API returned HTTP ${res.status}`);
+  }
+  const data = await res.json() as AdzunaResponse;
+  return data.results ?? [];
+}
+
+function formatSalary(min?: number, max?: number): string {
+  if (!min && !max) return "";
+  if (min && max) return `$${Math.round(min / 1000)}k–$${Math.round(max / 1000)}k/yr`;
+  if (min) return `$${Math.round(min / 1000)}k+/yr`;
+  return `up to $${Math.round(max! / 1000)}k/yr`;
+}
+
+export async function runAggregatorScan(
+  opts: AggregatorScanOptions,
+  onProgress?: (msg: string) => void,
+): Promise<AggregatorScanResult> {
+  if (!opts.adzunaAppId || !opts.adzunaApiKey) {
+    return { status: "no-credentials", imported: 0, duplicates: 0, totalFound: 0, errors: ["Adzuna App ID and API Key are required — configure them in Settings → AI Provider"] };
+  }
+  if (opts.titles.length === 0) {
+    return { status: "error", imported: 0, duplicates: 0, totalFound: 0, errors: ["No target roles configured — add them in Profile"] };
+  }
+
+  const country = opts.country ?? "us";
+  const scanTimestamp = new Date().toISOString();
+  const isRemoteOnly = opts.remotePreference === "remote-only";
+  const locations = opts.locations.length > 0 ? opts.locations : [""];
+
+  const jobs: Array<{
+    id: string;
+    company: string;
+    position: string;
+    jobDescription: string;
+    url: string;
+    sourceUrl: string;
+    originalPostingUrl: string;
+    discoveredAt: string;
+    location: string;
+    salaryNotes: string;
+  }> = [];
+  const errors: string[] = [];
+  const seen = new Set<string>();
+
+  for (const title of opts.titles.slice(0, 5)) {
+    for (const location of locations.slice(0, 3)) {
+      const where = isRemoteOnly ? "remote" : location;
+      onProgress?.(`Searching Adzuna: "${title}"${where ? ` in "${where}"` : ""}…`);
+      try {
+        const results = await searchAdzuna(opts.adzunaAppId, opts.adzunaApiKey, title, where, country);
+        for (const job of results) {
+          if (seen.has(job.redirect_url)) continue;
+          seen.add(job.redirect_url);
+          jobs.push({
+            id: randomUUID(),
+            company: job.company.display_name,
+            position: job.title,
+            jobDescription: job.description,
+            url: job.redirect_url,
+            sourceUrl: job.redirect_url,
+            originalPostingUrl: "",
+            discoveredAt: new Date(job.created).toISOString(),
+            location: job.location.display_name,
+            salaryNotes: formatSalary(job.salary_min, job.salary_max),
+          });
+        }
+        onProgress?.(`Found ${results.length} jobs for "${title}"${where ? ` / "${where}"` : ""}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        errors.push(msg);
+        onProgress?.(`Warning: ${msg}`);
+        if (msg.includes("credentials")) {
+          return { status: "error", imported: 0, duplicates: 0, totalFound: 0, errors };
+        }
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+
+  if (jobs.length === 0) {
+    return { status: "ok", imported: 0, duplicates: 0, totalFound: 0, errors };
+  }
+
+  const ts = new Date().toISOString().replace(/:/g, "-").replace(/\..+/, "Z");
+  const filename = `adzuna-jobs-${ts}.json`;
+  const dir = getBrowserBoardImportDirectory();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const tmpPath = path.join(dir, `${filename}.tmp`);
+  const finalPath = path.join(dir, filename);
+
+  const payload = {
+    metadata: {
+      source: "adzuna",
+      scanTimestamp,
+      scanDurationSeconds: 0,
+      totalJobsDiscovered: jobs.length,
+      totalJobsValid: jobs.length,
+      totalJobsSkipped: 0,
+      searchCriteria: {
+        titles: opts.titles,
+        locations: opts.locations,
+        remotePreference: opts.remotePreference,
+      },
+      generatedBy: "Adzuna Aggregator Scanner v1.0",
+    },
+    jobs: jobs.map((j) => ({
+      ...j,
+      dataQuality: {
+        hasCompany: Boolean(j.company),
+        hasPosition: Boolean(j.position),
+        hasDescription: Boolean(j.jobDescription),
+        hasUrl: Boolean(j.url),
+        descriptionLength: j.jobDescription.length,
+        warnings: [],
+      },
+    })),
+    validationSummary: {
+      totalRecords: jobs.length,
+      validRecords: jobs.length,
+      invalidRecords: 0,
+      errors: [],
+    },
+  };
+
+  writeFileSync(tmpPath, JSON.stringify(payload, null, 2));
+  renameSync(tmpPath, finalPath);
+  onProgress?.(`Saved ${jobs.length} jobs to ${filename}`);
+
+  try {
+    const importResult = await importBrowserBoardJobs(finalPath);
+    return {
+      status: "ok",
+      imported: importResult.imported,
+      duplicates: importResult.duplicates,
+      totalFound: jobs.length,
+      errors: [...errors, ...importResult.errors],
+    };
+  } catch (err) {
+    errors.push(err instanceof Error ? err.message : String(err));
+    return { status: "error", imported: 0, duplicates: 0, totalFound: jobs.length, errors };
+  }
+}

--- a/src/lib/scanner/browser-board-sources.ts
+++ b/src/lib/scanner/browser-board-sources.ts
@@ -4,7 +4,8 @@ export const BROWSER_BOARD_SOURCES = [
   "workatastartup",
   "glassdoor",
   "indeed",
-  "monster"
+  "monster",
+  "adzuna"
 ] as const;
 
 export type BrowserBoardSource = (typeof BROWSER_BOARD_SOURCES)[number];
@@ -15,7 +16,8 @@ export type BrowserBoardScanType =
   | "workatastartup-browser-scan"
   | "glassdoor-browser-scan"
   | "indeed-browser-scan"
-  | "monster-browser-scan";
+  | "monster-browser-scan"
+  | "adzuna-api-scan";
 
 const SOURCE_LABELS: Record<BrowserBoardSource, string> = {
   linkedin: "LinkedIn",
@@ -23,7 +25,8 @@ const SOURCE_LABELS: Record<BrowserBoardSource, string> = {
   workatastartup: "Work at a Startup",
   glassdoor: "Glassdoor",
   indeed: "Indeed",
-  monster: "Monster"
+  monster: "Monster",
+  adzuna: "Adzuna"
 };
 
 const SOURCE_TO_SCAN_TYPE: Record<BrowserBoardSource, BrowserBoardScanType> = {
@@ -32,7 +35,8 @@ const SOURCE_TO_SCAN_TYPE: Record<BrowserBoardSource, BrowserBoardScanType> = {
   workatastartup: "workatastartup-browser-scan",
   glassdoor: "glassdoor-browser-scan",
   indeed: "indeed-browser-scan",
-  monster: "monster-browser-scan"
+  monster: "monster-browser-scan",
+  adzuna: "adzuna-api-scan"
 };
 
 const SCAN_TYPE_TO_SOURCE: Record<BrowserBoardScanType, BrowserBoardSource> = {
@@ -41,7 +45,8 @@ const SCAN_TYPE_TO_SOURCE: Record<BrowserBoardScanType, BrowserBoardSource> = {
   "workatastartup-browser-scan": "workatastartup",
   "glassdoor-browser-scan": "glassdoor",
   "indeed-browser-scan": "indeed",
-  "monster-browser-scan": "monster"
+  "monster-browser-scan": "monster",
+  "adzuna-api-scan": "adzuna"
 };
 
 export function isBrowserBoardSource(value: unknown): value is BrowserBoardSource {

--- a/src/lib/scanner/source-discovery.ts
+++ b/src/lib/scanner/source-discovery.ts
@@ -442,3 +442,154 @@ export async function runSourceDiscovery(
     unknown: validated.filter((e) => e.validationStatus === "unknown").length,
   };
 }
+
+// ─── Search-based Discovery ───────────────────────────────────────────────────
+
+type BraveSearchResult = { url?: string; title?: string };
+type BraveSearchResponse = { web?: { results?: BraveSearchResult[] } };
+
+const SEARCH_PATTERNS: Array<{ query: string; provider: AtsProvider }> = [
+  { query: "site:jobs.ashbyhq.com", provider: "ashby" },
+  { query: "site:jobs.lever.co", provider: "lever" },
+  { query: "site:boards.greenhouse.io", provider: "greenhouse" },
+  { query: "site:job-boards.greenhouse.io", provider: "greenhouse" },
+];
+
+const BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search";
+const BRAVE_PAGES_PER_PATTERN = 5;
+const BRAVE_RESULTS_PER_PAGE = 20;
+
+async function queryBraveSearch(
+  apiKey: string,
+  query: string,
+  offset: number,
+): Promise<BraveSearchResult[]> {
+  const params = new URLSearchParams({
+    q: query,
+    count: String(BRAVE_RESULTS_PER_PAGE),
+    offset: String(offset),
+    search_lang: "en",
+    text_decorations: "false",
+    spellcheck: "false",
+  });
+  const res = await safeFetch(`${BRAVE_SEARCH_URL}?${params}`, {
+    headers: {
+      Accept: "application/json",
+      "Accept-Encoding": "gzip",
+      "X-Subscription-Token": apiKey,
+    },
+  });
+  if (!res.ok) throw new Error(`Brave Search returned HTTP ${res.status}`);
+  const data = await res.json() as BraveSearchResponse;
+  return data.web?.results ?? [];
+}
+
+export function loadDiscoveredEntries(): DiscoveredEntry[] {
+  if (!existsSync(OUTPUT_PATH)) return [];
+  try {
+    const data = JSON.parse(readFileSync(OUTPUT_PATH, "utf-8")) as DiscoveredSources;
+    return data.entries ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export async function runSearchDiscovery(
+  braveApiKey: string,
+  onProgress?: (msg: string) => void,
+): Promise<DiscoverySummary> {
+  if (!braveApiKey) throw new Error("Brave Search API key is required");
+
+  const existingSlugs = loadExistingSlugs();
+  // Also skip slugs already discovered in previous runs
+  const prevEntries = loadDiscoveredEntries();
+  const prevKeys = new Set(prevEntries.map(entryStableId));
+
+  const seen = new Map<string, DiscoveredEntry>();
+  let totalCrawled = 0;
+
+  for (const { query, provider } of SEARCH_PATTERNS) {
+    onProgress?.(`Searching Brave: ${query}…`);
+    for (let page = 0; page < BRAVE_PAGES_PER_PATTERN; page++) {
+      const offset = page * BRAVE_RESULTS_PER_PAGE;
+      let results: BraveSearchResult[] = [];
+      try {
+        results = await queryBraveSearch(braveApiKey, query, offset);
+      } catch (err) {
+        onProgress?.(`Warning: Brave Search failed for ${query} offset ${offset}: ${(err as Error).message}`);
+        break;
+      }
+      if (results.length === 0) break;
+      totalCrawled += results.length;
+
+      for (const { url } of results) {
+        if (!url) continue;
+        const slug = extractSlug(url);
+        if (!slug || existingSlugs.has(slug)) continue;
+        const key = `${provider}::${slug}`;
+        if (seen.has(key) || prevKeys.has(key)) continue;
+        seen.set(key, {
+          slug,
+          provider,
+          careersUrl: buildCareersUrl(slug, provider),
+          apiUrl: buildApiUrl(slug, provider),
+          validationStatus: "unknown",
+          checkedAt: null,
+          snapshotDate: null,
+          companyDisplayName: null,
+          industry: null,
+        });
+      }
+      if (results.length < BRAVE_RESULTS_PER_PAGE) break;
+      await new Promise((r) => setTimeout(r, 300));
+    }
+  }
+
+  const candidates = [...seen.values()];
+  onProgress?.(`Validating ${candidates.length} new slugs from search…`);
+
+  const validated = await validateInBatches(candidates, (done, total) => {
+    onProgress?.(`Validating ${done}/${total}…`);
+  });
+
+  const industryById = await classifyIndustriesWithAI(validated, onProgress);
+  const withIndustries = validated.map((e) => {
+    const id = entryStableId(e);
+    let industry = industryById.get(id) ?? null;
+    if (e.validationStatus === "valid" && !industry) {
+      industry = heuristicIndustry(e.slug);
+    }
+    const companyDisplayName =
+      e.companyDisplayName?.trim() ||
+      (e.validationStatus === "valid" ? labelFromSlug(e.slug) : null);
+    return { ...e, companyDisplayName, industry };
+  });
+
+  // Merge with existing entries — new entries added, existing untouched
+  const merged = [...prevEntries];
+  for (const entry of withIndustries) {
+    const key = entryStableId(entry);
+    if (!prevKeys.has(key)) merged.push(entry);
+  }
+
+  const output: DiscoveredSources = {
+    fetchedAt: new Date().toISOString(),
+    totalCrawled,
+    entries: merged.sort(
+      (a, b) => a.provider.localeCompare(b.provider) || a.slug.localeCompare(b.slug),
+    ),
+  };
+
+  if (!existsSync(path.dirname(OUTPUT_PATH))) {
+    mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  }
+  writeFileSync(OUTPUT_PATH, JSON.stringify(output, null, 2));
+
+  return {
+    totalCrawled,
+    newSlugs: candidates.length,
+    valid: validated.filter((e) => e.validationStatus === "valid").length,
+    dead: validated.filter((e) => e.validationStatus === "dead").length,
+    unknown: validated.filter((e) => e.validationStatus === "unknown").length,
+  };
+}

--- a/src/lib/scanner/source-validator.ts
+++ b/src/lib/scanner/source-validator.ts
@@ -1,0 +1,90 @@
+import { safeFetch } from "@/lib/safe-fetch";
+import { buildApiUrl, type AtsProvider } from "./source-discovery";
+
+const VALIDATE_TIMEOUT_MS = 10_000;
+const VALIDATE_CONCURRENCY = 8;
+const INTER_BATCH_DELAY_MS = 300;
+
+export type SourceValidationStatus = "valid" | "dead" | "unknown";
+
+export type SourceValidationResult = {
+  name: string;
+  status: SourceValidationStatus;
+  jobCount: number | null;
+  checkedAt: string;
+  error?: string;
+};
+
+type SourceInput = {
+  name: string;
+  careersUrl: string;
+  apiType: "greenhouse" | "ashby" | "lever" | null;
+};
+
+function getApiUrl(source: SourceInput): string | null {
+  if (!source.apiType) return null;
+  const url = source.careersUrl;
+  let slug: string | null = null;
+  if (source.apiType === "greenhouse") {
+    const m = url.match(/(?:boards|job-boards)\.greenhouse\.io\/([^/?#]+)/);
+    slug = m?.[1] ?? null;
+  } else if (source.apiType === "lever") {
+    const m = url.match(/jobs\.lever\.co\/([^/?#]+)/);
+    slug = m?.[1] ?? null;
+  } else if (source.apiType === "ashby") {
+    const m = url.match(/jobs\.ashbyhq\.com\/([^/?#]+)/i);
+    slug = m?.[1] ?? null;
+  }
+  if (!slug) return null;
+  return buildApiUrl(slug, source.apiType as AtsProvider);
+}
+
+function countJobs(json: unknown, apiType: "greenhouse" | "ashby" | "lever"): number | null {
+  if (!json || typeof json !== "object") return null;
+  if (apiType === "lever") return Array.isArray(json) ? json.length : null;
+  const rec = json as Record<string, unknown>;
+  return Array.isArray(rec.jobs) ? (rec.jobs as unknown[]).length : null;
+}
+
+async function validateSource(source: SourceInput): Promise<SourceValidationResult> {
+  const checkedAt = new Date().toISOString();
+  const apiUrl = getApiUrl(source);
+  if (!apiUrl) {
+    return { name: source.name, status: "unknown", jobCount: null, checkedAt, error: "Cannot determine API URL" };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), VALIDATE_TIMEOUT_MS);
+  try {
+    const res = await safeFetch(apiUrl, { signal: controller.signal });
+    const text = await res.text();
+    if (!res.ok) {
+      return { name: source.name, status: res.status === 404 ? "dead" : "unknown", jobCount: null, checkedAt };
+    }
+    let jobCount: number | null = null;
+    try {
+      jobCount = source.apiType ? countJobs(JSON.parse(text) as unknown, source.apiType) : null;
+    } catch { /* non-JSON */ }
+    return { name: source.name, status: "valid", jobCount, checkedAt };
+  } catch (err) {
+    return { name: source.name, status: "unknown", jobCount: null, checkedAt, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function validateAllSources(
+  sources: SourceInput[],
+  onProgress?: (done: number, total: number) => void,
+): Promise<SourceValidationResult[]> {
+  const results: SourceValidationResult[] = [];
+  for (let i = 0; i < sources.length; i += VALIDATE_CONCURRENCY) {
+    const batch = sources.slice(i, i + VALIDATE_CONCURRENCY);
+    const validated = await Promise.all(batch.map(validateSource));
+    results.push(...validated);
+    onProgress?.(Math.min(i + VALIDATE_CONCURRENCY, sources.length), sources.length);
+    if (i + VALIDATE_CONCURRENCY < sources.length) {
+      await new Promise((r) => setTimeout(r, INTER_BATCH_DELAY_MS));
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
… aggregator

Feature 1 — Bulk import & validation:
- New source-validator.ts: validates tracked ATS sources via their APIs (valid/dead/unknown + job count), runs 8 concurrent with backoff
- Settings Sources tab: "Import all valid (N)" button to bulk-import all validated discovered sources without opening the modal
- ScanSourcesTable: "Validate sources" button above the table with per-row live/dead/unknown badge column

Feature 2 — Brave Search-based discovery:
- source-discovery.ts: runSearchDiscovery() queries Brave Search API for site:jobs.ashbyhq.com, site:jobs.lever.co, site:boards.greenhouse.io patterns (up to 5 pages/pattern), merges new slugs into discovered-sources.json
- Settings Sources tab: "Search discover" button shown when Brave Search API key is configured
- AI Provider settings: Brave Search API Key field added

Feature 3 — Adzuna job aggregator:
- New aggregator-scanner.ts: queries Adzuna API for each target role/location from user profile, writes adzuna-jobs-<ts>.json and imports via browser-board pipeline
- New POST /api/aggregator/scan route
- New AggregatorScanButton client component with result summary
- Settings Sources tab: "Job aggregators" card with scan button
- AI Provider settings: Adzuna App ID + API Key fields added

DB migration 0037: adds brave_search_api_key, adzuna_app_id, adzuna_api_key to ai_settings "adzuna" added to BROWSER_BOARD_SOURCES with scan type "adzuna-api-scan"

https://claude.ai/code/session_012uCfZTvLXG8UdvfAXp9FZL

## Summary

What changed?

## Why it matters

What user problem does this solve?

## Testing

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run build`
- [ ] Manual browser check
- [ ] Accessibility check, if UI changed

## Screenshots

Add screenshots for UI changes.

## Risk check

- [ ] Does not expose personal data
- [ ] Does not add hidden telemetry
- [ ] Does not enable auto-submitting applications
- [ ] Does not bypass third-party platform restrictions
- [ ] Does not weaken local-first privacy
- [ ] Does not violate the non-commercial license position
