### PR TITLE
Add Adzuna aggregator, Brave Search discovery, source validation, and bulk import

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -601,13 +601,14 @@ custom URLs configured in Settings.
 
 **How a scan works:**
 1. User clicks "Scan for new jobs" on the Dashboard.
-2. The scanner queries each enabled source for open roles.
-3. Title filters remove irrelevant roles.
-4. Profile location and remote preferences remove listings outside the user's constraints.
-5. Duplicate URLs are skipped.
-6. New jobs are written to the `jobs` table with `status = found`.
-7. A `scan_runs` record is created with metrics.
-8. The Dashboard updates with the scan summary.
+2. The CareerOps ATS scanner queries each enabled Ashby/Greenhouse/Lever source in parallel.
+3. If Adzuna credentials are configured (Settings → AI Provider → Discovery & Aggregators), an Adzuna aggregator scan runs in parallel alongside the ATS scan.
+4. Title filters remove irrelevant roles.
+5. Profile location and remote preferences remove listings outside the user's constraints.
+6. Duplicate URLs are skipped.
+7. New jobs are written to the `jobs` table with `status = found`.
+8. A `scan_runs` record is created with metrics.
+9. The Dashboard updates with a combined scan summary (ATS + Adzuna totals merged).
 
 The Jobs page can also verify whether saved postings still exist. The liveness
 check updates `liveness_status` but does not automatically archive or delete

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,6 +117,28 @@ content. You can use whichever service you have access to:
 Once you have a key, you configure it inside the app itself (Settings → AI
 Providers). You do not need to create any configuration files manually.
 
+### 5a. Optional: Add job aggregator and source discovery keys
+
+These are not required to use the app, but they significantly expand how many
+jobs and sources the app can find automatically.
+
+**Adzuna** (job aggregator — free tier, 2,000 queries/month):
+- Register at [developer.adzuna.com](https://developer.adzuna.com) to get a
+  free App ID and API Key.
+- Once configured in Settings → AI Provider → Discovery & Aggregators, the
+  Dashboard **Scan for new jobs** button automatically runs an Adzuna scan in
+  parallel with the ATS scan — no extra step needed.
+- You can also run it independently from Settings → Sources → Job aggregators.
+
+**Brave Search** (ATS source discovery — free tier, 2,000 queries/month):
+- Register at [brave.com/search/api](https://brave.com/search/api) to get a
+  free API key.
+- Once configured, the **Search discover** button appears in Settings → Sources
+  and finds new Ashby, Greenhouse, and Lever companies from live web search
+  results (not just the Common Crawl archive).
+
+Add both keys in Settings → AI Provider → Discovery & Aggregators.
+
 ### 6. Start the app
 
 ```bash
@@ -171,7 +193,8 @@ for new jobs" to start discovering opportunities.
 
 | What you want to do | Where to go |
 |---|---|
-| Find new jobs | Dashboard → Scan for new jobs |
+| Find new jobs (ATS + Adzuna if configured) | Dashboard → Scan for new jobs |
+| Scan Adzuna independently | Settings → Sources → Job aggregators |
 | Add a job from anywhere | Jobs → Add Job button |
 | See all your jobs | Jobs |
 | Evaluate a job | Jobs → click a job → Evaluation tab |
@@ -184,8 +207,11 @@ for new jobs" to start discovering opportunities.
 | Update your profile | Account → Profile |
 | Upload or replace a resume | Account → Profile → Resumes tab |
 | Add an AI key | Account → Settings → AI Providers |
+| Add Adzuna or Brave Search keys | Account → Settings → AI Providers → Discovery & Aggregators |
+| Discover new ATS sources | Settings → Sources → Scan for new sources or Search discover |
+| Bulk-add validated discovered sources | Settings → Sources → Import all valid |
+| Check which sources are still live | Settings → Sources → Validate sources |
 | See role fit strategy | Account → Strategy |
-| Change AI provider or add sources | Account → Settings |
 
 ---
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import {
 import { SCAN_RESULT_JOBS_PREVIEW_MAX } from "@/lib/scan-result-constants";
 import type { ScanJobResultSummary } from "@/lib/scan-result-types";
 import { isScanSourceEnabled, runCareerOpsScanner } from "@/lib/scanner/careerops-scanner";
+import { runAggregatorScan } from "@/lib/scanner/aggregator-scanner";
 import { cn } from "@/lib/utils";
 import { ApplyNextCard, InFlightCard } from "@/components/action-queue-card";
 import { LocalDateLabel, LocalRelativeTimeLabel } from "@/components/local-time-label";
@@ -29,21 +30,44 @@ export default function DashboardPage() {
   async function scanForJobsAction(): Promise<ScanJobResultSummary> {
     "use server";
 
-    const result = await runCareerOpsScanner();
+    const settings = getAISettings();
+    const profile = getUserProfile();
+    const hasAdzuna = Boolean(settings.adzunaAppId && settings.adzunaApiKey);
+
+    const [careerOps, adzuna] = await Promise.all([
+      runCareerOpsScanner(),
+      hasAdzuna
+        ? runAggregatorScan({
+            adzunaAppId: settings.adzunaAppId,
+            adzunaApiKey: settings.adzunaApiKey,
+            titles: profile.targetRoles,
+            locations: profile.preferredLocations,
+            remotePreference: profile.remotePreference,
+          })
+        : null,
+    ]);
+
     revalidatePath("/dashboard");
     revalidatePath("/jobs");
-    const jobs = result.jobs;
+
+    const jobs = careerOps.jobs;
     const max = SCAN_RESULT_JOBS_PREVIEW_MAX;
+    const adzunaErrors = adzuna?.errors.map((e) => ({ company: "Adzuna", error: e })) ?? [];
+    const combinedStatus =
+      careerOps.status === "failed" ? "failed" :
+      (careerOps.status === "completed_with_errors" || adzuna?.status === "error") ? "completed_with_errors" :
+      "completed";
+
     return {
       companyName: "All enabled sources",
-      status: result.status,
-      newJobsCount: result.newJobsCount,
-      totalJobsFound: result.totalJobsFound,
-      filteredCount: result.filteredCount,
-      duplicateCount: result.duplicateCount,
-      companiesScanned: result.companiesScanned,
-      skippedCompanies: result.skippedCompanies,
-      errors: result.errors,
+      status: combinedStatus,
+      newJobsCount: careerOps.newJobsCount + (adzuna?.imported ?? 0),
+      totalJobsFound: careerOps.totalJobsFound + (adzuna?.totalFound ?? 0),
+      filteredCount: careerOps.filteredCount,
+      duplicateCount: careerOps.duplicateCount + (adzuna?.duplicates ?? 0),
+      companiesScanned: careerOps.companiesScanned,
+      skippedCompanies: careerOps.skippedCompanies,
+      errors: [...careerOps.errors, ...adzunaErrors],
       jobs: jobs.slice(0, max).map((j) => ({ title: j.title, url: j.url, company: j.company })),
       jobsTotal: jobs.length > max ? jobs.length : undefined,
     };

--- a/src/lib/help/content.ts
+++ b/src/lib/help/content.ts
@@ -55,9 +55,9 @@ export const helpPages: HelpPage[] = [
     slug: "getting-started",
     title: "Getting started with Job Search Terminal",
     shortTitle: "Getting started",
-    description: "Set up the local app, finish onboarding, and understand the core workflow before your first job scan.",
+    description: "Set up the local app, finish onboarding, add optional Adzuna and Brave keys, and understand the core workflow.",
     category: "Setup",
-    readTime: "8 min",
+    readTime: "10 min",
     icon: "laptop",
     image: {
       src: "/images/job-search-terminal/job-search-terminal-dashboard.png",
@@ -65,15 +65,15 @@ export const helpPages: HelpPage[] = [
     },
     highlights: [
       "Everything runs locally on your machine.",
-      "The app needs one AI provider key, at least one resume lane, and confirmed search preferences.",
-      "The Dashboard becomes your command center after setup is complete.",
+      "One AI provider key is required; Adzuna and Brave Search keys are optional but expand coverage significantly.",
+      "The Dashboard scan runs ATS sources and Adzuna together once credentials are configured.",
     ],
     sections: [
       {
         id: "what-it-is",
         title: "What this app does",
         intro:
-          "Job Search Terminal is a local-first job-search workspace. It scans supported career sources, imports manual and browser-board jobs, evaluates fit with AI, generates tailored resumes, prepares application answers, and tracks every application through the funnel.",
+          "Job Search Terminal is a local-first job-search workspace. It scans supported career sources, imports manual and browser-board jobs, pulls jobs from aggregator APIs, evaluates fit with AI, generates tailored resumes, prepares application answers, and tracks every application through the funnel.",
         bullets: [
           "No cloud account is required for the app itself.",
           "Your profile, resumes, generated documents, jobs, and application history stay on your computer.",
@@ -89,15 +89,15 @@ export const helpPages: HelpPage[] = [
         steps: [
           {
             title: "Add one AI provider key",
-            body: "Open Account -> Settings -> AI Providers, choose OpenAI, Anthropic, or Google Gemini, paste the key, save, and test the connection.",
+            body: "Open Account → Settings → AI Providers, choose OpenAI, Anthropic, or Google Gemini, paste the key, save, and test the connection.",
           },
           {
             title: "Upload your base resumes",
-            body: "Open Account -> Profile -> Resumes. Upload each PDF into the lane that matches its career angle, such as Leadership, IC, Operations, or Consulting.",
+            body: "Open Account → Profile → Resumes. Upload each PDF into the lane that matches its career angle, such as Leadership, IC, Operations, or Consulting.",
           },
           {
             title: "Extract your profile",
-            body: "Open Account -> Profile -> Overview and run Extract with AI after at least one resume has been uploaded. Review the extracted profile before using it.",
+            body: "Open Account → Profile → Overview and run Extract with AI after at least one resume has been uploaded. Review the extracted profile before using it.",
           },
           {
             title: "Confirm preferences",
@@ -105,9 +105,29 @@ export const helpPages: HelpPage[] = [
           },
           {
             title: "Run your first scan",
-            body: "Return to the Dashboard and use Scan for new jobs. New jobs appear in Jobs, where they can be filtered, evaluated, skipped, archived, or moved into the application funnel.",
+            body: "Return to the Dashboard and click Scan for new jobs. The scan checks all enabled ATS career portals and, if Adzuna credentials are configured, runs an Adzuna aggregator scan in parallel. New jobs appear in Jobs.",
           },
         ],
+      },
+      {
+        id: "optional-keys",
+        title: "Optional: expand job coverage",
+        intro:
+          "Two free API keys unlock additional job sources and source discovery. Neither is required to use the core app.",
+        steps: [
+          {
+            title: "Adzuna (job aggregator)",
+            body: "Register at developer.adzuna.com for a free App ID and API Key (2,000 queries/month). Add both in Account → Settings → AI Provider → Discovery & Aggregators. Once set, the Dashboard scan automatically includes Adzuna results alongside ATS sources — no extra step needed.",
+          },
+          {
+            title: "Brave Search (source discovery)",
+            body: "Register at brave.com/search/api for a free API key (2,000 queries/month). Add it in Account → Settings → AI Provider → Discovery & Aggregators. Once set, the Search discover button appears in Settings → Sources and finds new companies using Ashby, Greenhouse, or Lever from live search results.",
+          },
+        ],
+        callout: {
+          title: "Already tracking 50+ ATS sources",
+          body: "The app ships with ~50 curated companies in portals.yml. Use Settings → Sources → Scan for new sources (Common Crawl) or Search discover (Brave) to find more, then Validate sources to confirm which are live and Import all valid to add them in bulk.",
+        },
       },
       {
         id: "daily-loop",
@@ -115,7 +135,7 @@ export const helpPages: HelpPage[] = [
         steps: [
           {
             title: "Scan or import",
-            body: "Use the Dashboard scan, manual Add Job, or the browser job board scanner to bring new postings into the pipeline.",
+            body: "Click Scan for new jobs on the Dashboard — ATS portals and Adzuna (if configured) run together. Or use manual Add Job, or the browser job board scanner for LinkedIn and similar boards.",
           },
           {
             title: "Review and evaluate",
@@ -132,7 +152,7 @@ export const helpPages: HelpPage[] = [
         ],
       },
     ],
-    related: ["ai-providers", "resume-lanes", "job-search"],
+    related: ["ai-providers", "job-search", "linkedin-scanner"],
   },
   {
     slug: "ai-providers",

--- a/src/lib/help/content.ts
+++ b/src/lib/help/content.ts
@@ -446,11 +446,11 @@ export const helpPages: HelpPage[] = [
           },
           {
             title: "Start the scan",
-            body: "Click Scan for new jobs from the Dashboard. The app checks enabled sources and applies your title and location constraints before inserting jobs.",
+            body: "Click Scan for new jobs from the Dashboard. The app checks all enabled ATS sources and, if Adzuna credentials are configured, also runs an Adzuna aggregator scan in parallel.",
           },
           {
             title: "Read the scan summary",
-            body: "The Dashboard reports companies scanned, new jobs, filtered jobs, duplicates, skipped sources, and source errors.",
+            body: "The Dashboard reports companies scanned, new jobs (ATS + Adzuna combined), filtered jobs, duplicates, skipped sources, and any source errors.",
           },
         ],
       },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Adzuna aggregator** — direct API scan without a browser; runs automatically alongside ATS sources when the Dashboard "Scan for new jobs" button is clicked if credentials are configured; also available independently from Settings → Sources
- **Brave Search discovery** — find new Ashby/Greenhouse/Lever companies from live search results instead of the Common Crawl archive; appears in Settings → Sources when a Brave API key is set
- **Import all valid** — bulk-add all validated discovered sources in one click; no more clicking each one individually
- **Validate sources** — checks every tracked career portal's API live; shows per-row Live/job-count, Dead, or Unknown badge in the scan sources table
- **DB migration 0037** — adds `brave_search_api_key`, `adzuna_app_id`, `adzuna_api_key` to `ai_settings`
- **Docs + Help** — `docs/getting-started.md`, `docs/features.md`, `docs/data-model.md`, `docs/browser-board-scanner-technical.md`, and all relevant `help/content.ts` pages updated

## What changed

| File | Change |
|---|---|
| `src/lib/scanner/aggregator-scanner.ts` | New — Adzuna API scanner |
| `src/lib/scanner/source-validator.ts` | New — validates tracked ATS sources |
| `src/lib/scanner/source-discovery.ts` | Added `runSearchDiscovery` (Brave Search) |
| `src/lib/scanner/browser-board-sources.ts` | Added `"adzuna"` source type |
| `src/app/api/aggregator/scan/route.ts` | New — POST endpoint for Adzuna scan |
| `src/app/dashboard/page.tsx` | `scanForJobsAction` runs Adzuna in parallel when credentials present |
| `src/app/settings/page.tsx` | New server actions: importAllValid, validateAll, searchDiscover, aggregatorScan |
| `src/components/aggregator-scan-button.tsx` | New — Adzuna scan button with result display |
| `src/components/scan-sources-table.tsx` | Validate all button + per-row live/dead badge column |
| `src/components/ai-settings-form.tsx` | Discovery & Aggregators key fields |
| `src/app/settings/actions.ts` | Handles new key fields |
| `src/lib/db/schema.ts` | Migration 0037 |
| `src/lib/db/types.ts` | New fields on `AISettingsRecord` |
| `src/lib/db/queries.ts` | Updated AI settings read/write |

## Test plan

- [ ] Dashboard scan with no Adzuna keys — behaves identically to before
- [ ] Dashboard scan with Adzuna keys — combined summary shows ATS + Adzuna counts
- [ ] Settings → Sources → Validate sources — per-row Live/Dead/Unknown badges appear
- [ ] Settings → Sources → Import all valid — all valid discovered sources added in one click
- [ ] Settings → Sources → Search discover — only visible when Brave key is set
- [ ] Settings → Sources → Job aggregators card — only visible when Adzuna keys are set
- [ ] AI Provider settings — Discovery & Aggregators section saves and masks keys correctly
- [ ] Jobs table — Adzuna source badge appears on imported jobs

https://claude.ai/code/session_012uCfZTvLXG8UdvfAXp9FZL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCfZTvLXG8UdvfAXp9FZL)_