### PR TITLE
Fix Codex review: aggregator status and job preview bugs

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -50,13 +50,18 @@ export default function DashboardPage() {
     revalidatePath("/dashboard");
     revalidatePath("/jobs");
 
-    const jobs = careerOps.jobs;
     const max = SCAN_RESULT_JOBS_PREVIEW_MAX;
     const adzunaErrors = adzuna?.errors.map((e) => ({ company: "Adzuna", error: e })) ?? [];
+    const adzunaHasErrors = (adzuna?.errors.length ?? 0) > 0;
     const combinedStatus =
       careerOps.status === "failed" ? "failed" :
-      (careerOps.status === "completed_with_errors" || adzuna?.status === "error") ? "completed_with_errors" :
+      (careerOps.status === "completed_with_errors" || adzuna?.status === "error" || adzunaHasErrors) ? "completed_with_errors" :
       "completed";
+
+    const allJobs = [
+      ...careerOps.jobs.map((j) => ({ title: j.title, url: j.url, company: j.company })),
+      ...(adzuna?.jobs ?? []),
+    ];
 
     return {
       companyName: "All enabled sources",
@@ -68,8 +73,8 @@ export default function DashboardPage() {
       companiesScanned: careerOps.companiesScanned,
       skippedCompanies: careerOps.skippedCompanies,
       errors: [...careerOps.errors, ...adzunaErrors],
-      jobs: jobs.slice(0, max).map((j) => ({ title: j.title, url: j.url, company: j.company })),
-      jobsTotal: jobs.length > max ? jobs.length : undefined,
+      jobs: allJobs.slice(0, max),
+      jobsTotal: allJobs.length > max ? allJobs.length : undefined,
     };
   }
 

--- a/src/lib/scanner/aggregator-scanner.ts
+++ b/src/lib/scanner/aggregator-scanner.ts
@@ -19,6 +19,7 @@ export type AggregatorScanResult = {
   duplicates: number;
   totalFound: number;
   errors: string[];
+  jobs: Array<{ title: string; url: string; company: string }>;
 };
 
 type AdzunaJob = {
@@ -77,10 +78,10 @@ export async function runAggregatorScan(
   onProgress?: (msg: string) => void,
 ): Promise<AggregatorScanResult> {
   if (!opts.adzunaAppId || !opts.adzunaApiKey) {
-    return { status: "no-credentials", imported: 0, duplicates: 0, totalFound: 0, errors: ["Adzuna App ID and API Key are required — configure them in Settings → AI Provider"] };
+    return { status: "no-credentials", imported: 0, duplicates: 0, totalFound: 0, errors: ["Adzuna App ID and API Key are required — configure them in Settings → AI Provider"], jobs: [] };
   }
   if (opts.titles.length === 0) {
-    return { status: "error", imported: 0, duplicates: 0, totalFound: 0, errors: ["No target roles configured — add them in Profile"] };
+    return { status: "error", imported: 0, duplicates: 0, totalFound: 0, errors: ["No target roles configured — add them in Profile"], jobs: [] };
   }
 
   const country = opts.country ?? "us";
@@ -139,7 +140,7 @@ export async function runAggregatorScan(
   }
 
   if (jobs.length === 0) {
-    return { status: "ok", imported: 0, duplicates: 0, totalFound: 0, errors };
+    return { status: "ok", imported: 0, duplicates: 0, totalFound: 0, errors, jobs: [] };
   }
 
   const ts = new Date().toISOString().replace(/:/g, "-").replace(/\..+/, "Z");
@@ -187,6 +188,7 @@ export async function runAggregatorScan(
   renameSync(tmpPath, finalPath);
   onProgress?.(`Saved ${jobs.length} jobs to ${filename}`);
 
+  const preview = jobs.map((j) => ({ title: j.position, url: j.url, company: j.company }));
   try {
     const importResult = await importBrowserBoardJobs(finalPath);
     return {
@@ -195,9 +197,10 @@ export async function runAggregatorScan(
       duplicates: importResult.duplicates,
       totalFound: jobs.length,
       errors: [...errors, ...importResult.errors],
+      jobs: preview,
     };
   } catch (err) {
     errors.push(err instanceof Error ? err.message : String(err));
-    return { status: "error", imported: 0, duplicates: 0, totalFound: jobs.length, errors };
+    return { status: "error", imported: 0, duplicates: 0, totalFound: jobs.length, errors, jobs: preview };
   }
 }


### PR DESCRIPTION
Addresses both issues flagged in the Codex review of PR #9.

## Bug 1 — `combinedStatus` masked partial Adzuna failures

`runAggregatorScan` can return `status: "ok"` with a non-empty `errors` array (per-query failures, import warnings). The previous check only tested `adzuna.status === "error"`, so those partial failures were silently swallowed and the dashboard showed a green **Completed** badge while the errors list contained real problems.

**Fix:** added `|| (adzuna?.errors.length ?? 0) > 0` to the `completed_with_errors` branch.

## Bug 2 — Job preview only showed ATS results

The preview list (`jobs`) was built exclusively from `careerOps.jobs`. When ATS found nothing but Adzuna imported jobs, the scan summary modal showed "No new listings were added" while the badge correctly reported new job counts — a visible inconsistency.

**Fix:** added a `jobs: Array<{ title, url, company }>` field to `AggregatorScanResult` (populated at every return site) and merged both lists in the dashboard before slicing to `max`. `jobsTotal` now reflects the combined length for the truncation label.

https://claude.ai/code/session_012uCfZTvLXG8UdvfAXp9FZL

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCfZTvLXG8UdvfAXp9FZL)_