### PR TITLE
Fix missing jobs field on aggregator early-exit return path

### DIFF
--- a/src/lib/scanner/aggregator-scanner.ts
+++ b/src/lib/scanner/aggregator-scanner.ts
@@ -132,7 +132,7 @@ export async function runAggregatorScan(
         errors.push(msg);
         onProgress?.(`Warning: ${msg}`);
         if (msg.includes("credentials")) {
-          return { status: "error", imported: 0, duplicates: 0, totalFound: 0, errors };
+          return { status: "error", imported: 0, duplicates: 0, totalFound: 0, errors, jobs: [] };
         }
       }
       await new Promise((r) => setTimeout(r, 200));


### PR DESCRIPTION
The early-exit return inside the per-query `catch` block (`aggregator-scanner.ts:135`) was missed when `jobs` was added to `AggregatorScanResult` in PR #10. CI caught it: `Property 'jobs' is missing in type '{ status: "error"; ... }' but required in type 'AggregatorScanResult'`.

One-line fix — adds `jobs: []` to that return site. All 6 return paths in the function now satisfy the type.

https://claude.ai/code/session_012uCfZTvLXG8UdvfAXp9FZL

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCfZTvLXG8UdvfAXp9FZL)_