### PR TITLE
Fix: Adzuna preview shows only newly imported jobs

### DIFF
--- a/src/lib/scanner/aggregator-scanner.ts
+++ b/src/lib/scanner/aggregator-scanner.ts
@@ -197,7 +197,7 @@ export async function runAggregatorScan(
       duplicates: importResult.duplicates,
       totalFound: jobs.length,
       errors: [...errors, ...importResult.errors],
-      jobs: preview,
+      jobs: preview.slice(0, importResult.imported),
     };
   } catch (err) {
     errors.push(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary

- `runAggregatorScan` was returning `jobs: preview` built from all fetched Adzuna hits before dedup/import
- When a scan finds duplicates only (`imported: 0, duplicates: N`), the summary still rendered job links as if they were new listings
- Fix: slice `preview` to `importResult.imported` so the returned jobs array is consistent with the reported imported count

## Change

```ts
// before
jobs: preview,

// after
jobs: preview.slice(0, importResult.imported),
```

## Test plan
- [ ] Run Adzuna scan when all results are duplicates — `jobs` in summary should be empty
- [ ] Run Adzuna scan with some new results — `jobs` count should match `imported` count

---
_Generated by [Claude Code](https://claude.ai/code/session_012uCfZTvLXG8UdvfAXp9FZL)_