### PR TITLE
Add Jooble and Lensa to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,8 @@ Job Search Terminal is in early public development.
 - Improved generated resume editor
 - More interview prep workflows
 - Optional import/export flows
+- **Jooble API integration** — add Jooble as a second job aggregator source alongside Adzuna; free API key, same scan-and-import pattern, covers a broad range of listings from across the web
+- **Lensa browser-board source** — add Lensa as a browser-assisted scan target (Claude Desktop); no public API exists, so agent-driven browsing is the only viable path
 
 ## Not planned
 


### PR DESCRIPTION
## Summary

- Documents planned **Jooble API integration** as a second job aggregator source alongside Adzuna (free REST API, same scan-and-import pattern)
- Documents **Lensa as a browser-board scan target** — no public API exists, so Claude Desktop agent-driven browsing is the only viable path

## Research notes

Lensa has no developer API or portal. Jooble offers a free REST API (`POST https://jooble.org/api/{apiKey}`) that maps cleanly onto the existing Adzuna aggregator pattern — credentials in `ai_settings`, scan via `aggregator-scanner`, imported through `importBrowserBoardJobs()`.

## Test plan

- [ ] Confirm roadmap entries are accurate and clearly worded
- [ ] Implementation tracked in plan file for future execution

---
_Generated by [Claude Code](https://claude.ai/code/session_01LADYYAjUgGDHBrGsbUfPku)_